### PR TITLE
Remove onDateSelected call after composition

### DIFF
--- a/composeDatePicker/src/main/java/com/vsnappy1/datepicker/DatePicker.kt
+++ b/composeDatePicker/src/main/java/com/vsnappy1/datepicker/DatePicker.kt
@@ -171,14 +171,7 @@ fun DatePicker(
             }
         }
     }
-    // Call onDateSelected when composition is completed
-    LaunchedEffect(key1 = Unit) {
-        onDateSelected(
-            uiState.selectedYear,
-            uiState.selectedMonth.number,
-            uiState.selectedDayOfMonth
-        )
-    }
+   
 }
 
 @Composable


### PR DESCRIPTION
I removed the LaunchedEffect that calls onDateSelected after composition. When I tried to use this as a component, I faced a problem where this LaunchedEffect dismissed my component when it completed because I passed the change state with the function. I removed it to use the component as a whole, not just as a dialog, but as a component that can be used anywhere in my code